### PR TITLE
Add pre-built type constants to typector

### DIFF
--- a/typector/typector.go
+++ b/typector/typector.go
@@ -6,11 +6,9 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
 
-// Pre-built type constructors for all simple Spanner types.
+// Shorthand constructors for all simple Spanner types.
+// Each call returns a new *sppb.Type to prevent shared mutation across callers.
 // PROTO and ENUM are excluded because they require a fully qualified name.
-//
-// These are functions (not package-level vars) so that each call returns a fresh
-// *sppb.Type, preventing accidental shared mutation across callers and tests.
 
 func Bool() *sppb.Type      { return CodeToSimpleType(sppb.TypeCode_BOOL) }
 func Int64() *sppb.Type     { return CodeToSimpleType(sppb.TypeCode_INT64) }


### PR DESCRIPTION
## Summary
- Add shorthand constructor functions for all 12 simple Spanner types (`Bool()`, `Int64()`, `Float32()`, `Float64()`, `Timestamp()`, `Date()`, `String()`, `Bytes()`, `Numeric()`, `JSON()`, `Interval()`, `UUID()`)
- Allows `typector.Int64()` instead of `typector.CodeToSimpleType(sppb.TypeCode_INT64)`
- Each call returns a new `*sppb.Type` to prevent shared mutation across callers
- PROTO and ENUM are excluded because they require a fully qualified name

## Test plan
- [x] Existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)