### PR TITLE
Fix minor issues across the codebase

### DIFF
--- a/cmd/spantype/main.go
+++ b/cmd/spantype/main.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/apstndb/spantype"
-	"google.golang.org/protobuf/encoding/protojson"
 	"io"
+	"log"
+	"os"
 	"strings"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"log"
-	"os"
+	"github.com/apstndb/spantype"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func main() {
@@ -38,7 +38,7 @@ func modeToFormatOption(mode string) spantype.FormatOption {
 }
 
 func run(ctx context.Context) error {
-	mode := flag.String("mode", "verbose", "format mode (simplest|simple|normal|verbose)")
+	mode := flag.String("mode", "verbose", "format mode (simplest|simple|normal|verbose|more)")
 	flag.Parse()
 
 	formatOpt := modeToFormatOption(*mode)

--- a/format.go
+++ b/format.go
@@ -189,7 +189,7 @@ func FormatStructFields(fields []*sppb.StructType_Field, opts FormatOption) stri
 		if opts.Struct == StructModeRecursiveWithName && field.GetName() != "" {
 			fieldsStr = append(fieldsStr, fmt.Sprintf("%v %v", field.GetName(), typeStr))
 		} else {
-			fieldsStr = append(fieldsStr, fmt.Sprintf("%v", typeStr))
+			fieldsStr = append(fieldsStr, typeStr)
 		}
 	}
 	return strings.Join(fieldsStr, ", ")

--- a/format_test.go
+++ b/format_test.go
@@ -15,9 +15,9 @@ func TestFormatType(t *testing.T) {
 		typ             *sppb.Type
 		wantSimplest    string
 		wantSimple      string
+		wantNormal      string
 		wantVerbose     string
 		wantMoreVerbose string
-		wantNormal      string
 	}{
 		{
 			desc:            "UNKNOWN",
@@ -214,11 +214,11 @@ func TestFormatType(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got := FormatTypeSimple(tt.typ); tt.wantSimple != got {
-				t.Errorf("FormatTypeSimple want: %v, got: %v", tt.wantSimple, got)
-			}
 			if got := FormatTypeSimplest(tt.typ); tt.wantSimplest != got {
 				t.Errorf("FormatTypeSimplest want: %v, got: %v", tt.wantSimplest, got)
+			}
+			if got := FormatTypeSimple(tt.typ); tt.wantSimple != got {
+				t.Errorf("FormatTypeSimple want: %v, got: %v", tt.wantSimple, got)
 			}
 			if got := FormatTypeNormal(tt.typ); tt.wantNormal != got {
 				t.Errorf("FormatTypeNormal want: %v, got: %v", tt.wantNormal, got)
@@ -268,7 +268,7 @@ func TestFormatProtoEnum(t *testing.T) {
 			for _, mode := range []ProtoEnumMode{ProtoEnumModeBase, ProtoEnumModeLeaf, ProtoEnumModeFull, ProtoEnumModeLeafWithKind, ProtoEnumModeFullWithKind} {
 				t.Run(fmt.Sprint(mode), func(t *testing.T) {
 					if got := FormatProtoEnum(tt.typ, mode); tt.want[mode] != got {
-						t.Errorf("FormatTypeCode want: %v, got: %v", tt.want[mode], got)
+						t.Errorf("FormatProtoEnum want: %v, got: %v", tt.want[mode], got)
 					}
 				})
 


### PR DESCRIPTION
## Summary
- Fix wrong error message in `TestFormatProtoEnum` (`"FormatTypeCode"` -> `"FormatProtoEnum"`)
- Remove unnecessary `fmt.Sprintf("%v", typeStr)` in `FormatStructFields`
- Add missing `more` mode to flag help text in `cmd/spantype`
- Fix non-standard import grouping in `cmd/spantype`
- Reorder test struct fields and assertions to match logical verbosity order (Simplest < Simple < Normal < Verbose < MoreVerbose)

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)