### PR TITLE
feat: PostgreSQL TypeAnnotation formatting and typector helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Recent history uses short, imperative commit subjects with sentence case, for ex
 - test evidence such as `go test ./...`,
 - example input/output when CLI formatting changes.
 
+After pushing commits that address review feedback, request a fresh Copilot review with `gh copilot-review request <pr> --wait` (requires the [`gh-copilot-review`](https://github.com/apstndb/gh-copilot-review) `gh` extension), unless the user asks not to.
+
 ## Release Notes
 
 Use GitHub Releases for release notes instead of maintaining a repository changelog. Start from GitHub's auto-generated notes, then review `git log` for the range being released and add any missed consumer-facing changes such as new `typector` helpers, formatting-mode behavior, or compatibility notes.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The same mode applies recursively inside `ARRAY<>` and `STRUCT<>` fields.
 - Use shorthand constructors such as `Int64()`, `String()`, and `UUID()` for common scalar types.
 - Use `ElemCodeToArrayType` / `ElemTypeToArrayType` for arrays.
 - Use `FQNToProtoType` / `FQNToEnumType` for `PROTO` and `ENUM`, which require a fully-qualified name.
-- Use `SimpleTypeWithAnnotation`, `PGNumeric`, `PGJsonB`, or `PGOid` when you need PostgreSQL [`TypeAnnotation`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#Type) markers on scalars.
+- Use `SimpleTypeWithAnnotation`, `PGNumeric`, `PGJSONB`, or `PGOID` when you need PostgreSQL [`TypeAnnotation`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#Type) markers on scalars.
 - Prefer `...Code...` forms when your input is a type code, and `...Type...` forms when you already have `*spannerpb.Type`.
 
 ## CLI Example

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ echo '{"fields":[{"name":"n","type":{"code":"INT64"}}]}' | go run ./cmd/spantype
 ```
 
 Supported modes are `simplest`, `simple`, `normal`, `verbose`, and `more`.  
-Use `--type-annotation=suffix|omit|primary` to control `TypeAnnotation` rendering (default `suffix`).
+Use `--type-annotation=suffix|omit|primary` to control `TypeAnnotation` rendering (default `suffix`).  
+Unknown flags and invalid `--mode` / `--type-annotation` values are reported on stderr with a non-zero exit.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ The root package formats Spanner types with configurable verbosity. For a type l
 
 If you need custom behavior, call `FormatType` with `FormatOption`.
 
+**`Type.TypeAnnotation` (PostgreSQL dialect markers)**  
+[`FormatOption.TypeAnnotation`](https://pkg.go.dev/github.com/apstndb/spantype#FormatOption) selects how non-unspecified [`TypeAnnotationCode`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#TypeAnnotationCode) values are shown:
+
+| `TypeAnnotationMode` | Example (`NUMERIC` + `PG_NUMERIC`) |
+| --- | --- |
+| `TypeAnnotationModeSuffix` (default, zero value) | `NUMERIC(PG_NUMERIC)` |
+| `TypeAnnotationModeOmit` | `NUMERIC` |
+| `TypeAnnotationModePrimary` | `PG_NUMERIC` |
+
+The same mode applies recursively inside `ARRAY<>` and `STRUCT<>` fields.
+
 ### `typector`
 
 `typector` is a constructor helper package for building Spanner type values.
@@ -31,6 +42,7 @@ If you need custom behavior, call `FormatType` with `FormatOption`.
 - Use shorthand constructors such as `Int64()`, `String()`, and `UUID()` for common scalar types.
 - Use `ElemCodeToArrayType` / `ElemTypeToArrayType` for arrays.
 - Use `FQNToProtoType` / `FQNToEnumType` for `PROTO` and `ENUM`, which require a fully-qualified name.
+- Use `SimpleTypeWithAnnotation`, `PGNumeric`, `PGJsonB`, or `PGOid` when you need PostgreSQL [`TypeAnnotation`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#Type) markers on scalars.
 - Prefer `...Code...` forms when your input is a type code, and `...Type...` forms when you already have `*spannerpb.Type`.
 
 ## CLI Example
@@ -41,7 +53,8 @@ If you need custom behavior, call `FormatType` with `FormatOption`.
 echo '{"fields":[{"name":"n","type":{"code":"INT64"}}]}' | go run ./cmd/spantype --mode=verbose
 ```
 
-Supported modes are `simplest`, `simple`, `normal`, `verbose`, and `more`.
+Supported modes are `simplest`, `simple`, `normal`, `verbose`, and `more`.  
+Use `--type-annotation=suffix|omit|primary` to control `TypeAnnotation` rendering (default `suffix`).
 
 ## Development
 

--- a/cmd/spantype/README.md
+++ b/cmd/spantype/README.md
@@ -3,6 +3,8 @@ $ ./spantype --help
 Usage of ./spantype:
   -mode string
         format mode (simplest|simple|normal|verbose|more) (default "verbose")
+  -type-annotation string
+        how to render TypeAnnotation: suffix|omit|primary (default "suffix")
 
 $ gcloud spanner databases execute-sql ${SPANNER_DATABASE} \
     --format="json" --query-mode=PLAN \

--- a/cmd/spantype/README.md
+++ b/cmd/spantype/README.md
@@ -1,6 +1,6 @@
 ```shell
 $ ./spantype --help
-Usage of ./spantype:
+Usage of spantype:
   -mode string
         format mode (simplest|simple|normal|verbose|more) (default "verbose")
   -type-annotation string

--- a/cmd/spantype/main.go
+++ b/cmd/spantype/main.go
@@ -59,14 +59,15 @@ func run() error {
 	mode := fs.String("mode", "verbose", "format mode (simplest|simple|normal|verbose|more)")
 	typeAnn := fs.String("type-annotation", "suffix", "how to render TypeAnnotation: suffix|omit|primary")
 	if err := fs.Parse(os.Args[1:]); err != nil {
-		fs.SetOutput(os.Stderr)
 		if errors.Is(err, flag.ErrHelp) {
+			fs.SetOutput(os.Stderr)
 			fs.Usage()
 			return nil
 		}
-		fmt.Fprintln(os.Stderr, err)
+		var usage strings.Builder
+		fs.SetOutput(&usage)
 		fs.Usage()
-		os.Exit(1)
+		return fmt.Errorf("%w\n%s", err, strings.TrimRight(usage.String(), "\n"))
 	}
 
 	formatOpt, err := modeToFormatOption(*mode)

--- a/cmd/spantype/main.go
+++ b/cmd/spantype/main.go
@@ -53,14 +53,20 @@ func parseTypeAnnotationMode(s string) (spantype.TypeAnnotationMode, error) {
 
 func run() error {
 	fs := flag.NewFlagSet(filepath.Base(os.Args[0]), flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	// Discard while parsing so we do not duplicate the parse error on stderr when
+	// we print the message and usage ourselves (ContinueOnError writes to Output).
+	fs.SetOutput(io.Discard)
 	mode := fs.String("mode", "verbose", "format mode (simplest|simple|normal|verbose|more)")
 	typeAnn := fs.String("type-annotation", "suffix", "how to render TypeAnnotation: suffix|omit|primary")
 	if err := fs.Parse(os.Args[1:]); err != nil {
+		fs.SetOutput(os.Stderr)
 		if errors.Is(err, flag.ErrHelp) {
+			fs.Usage()
 			return nil
 		}
-		return err
+		fmt.Fprintln(os.Stderr, err)
+		fs.Usage()
+		os.Exit(1)
 	}
 
 	formatOpt, err := modeToFormatOption(*mode)

--- a/cmd/spantype/main.go
+++ b/cmd/spantype/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,12 +16,13 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatalln(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 
 func modeToFormatOption(mode string) (spantype.FormatOption, error) {
-	switch strings.ToLower(mode) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "more":
 		return spantype.FormatOptionMoreVerbose, nil
 	case "verbose":

--- a/cmd/spantype/main.go
+++ b/cmd/spantype/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -15,33 +14,55 @@ import (
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
+	if err := run(); err != nil {
 		log.Fatalln(err)
 	}
 }
 
-func modeToFormatOption(mode string) spantype.FormatOption {
+func modeToFormatOption(mode string) (spantype.FormatOption, error) {
 	switch strings.ToLower(mode) {
 	case "more":
-		return spantype.FormatOptionMoreVerbose
+		return spantype.FormatOptionMoreVerbose, nil
 	case "verbose":
-		return spantype.FormatOptionVerbose
+		return spantype.FormatOptionVerbose, nil
 	case "normal":
-		return spantype.FormatOptionNormal
+		return spantype.FormatOptionNormal, nil
 	case "simplest":
-		return spantype.FormatOptionSimplest
+		return spantype.FormatOptionSimplest, nil
 	case "simple":
-		return spantype.FormatOptionSimple
+		return spantype.FormatOptionSimple, nil
 	default:
-		panic("unknown mode: " + mode)
+		return spantype.FormatOption{}, fmt.Errorf("unknown mode %q (want simplest|simple|normal|verbose|more)", mode)
 	}
 }
 
-func run(ctx context.Context) error {
+func parseTypeAnnotationMode(s string) (spantype.TypeAnnotationMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "suffix", "":
+		return spantype.TypeAnnotationModeSuffix, nil
+	case "omit":
+		return spantype.TypeAnnotationModeOmit, nil
+	case "primary":
+		return spantype.TypeAnnotationModePrimary, nil
+	default:
+		return 0, fmt.Errorf("unknown type-annotation mode %q (want suffix|omit|primary)", s)
+	}
+}
+
+func run() error {
 	mode := flag.String("mode", "verbose", "format mode (simplest|simple|normal|verbose|more)")
+	typeAnn := flag.String("type-annotation", "suffix", "how to render TypeAnnotation: suffix|omit|primary")
 	flag.Parse()
 
-	formatOpt := modeToFormatOption(*mode)
+	formatOpt, err := modeToFormatOption(*mode)
+	if err != nil {
+		return err
+	}
+	annMode, err := parseTypeAnnotationMode(*typeAnn)
+	if err != nil {
+		return err
+	}
+	formatOpt.TypeAnnotation = annMode
 
 	b, err := io.ReadAll(os.Stdin)
 	if err != nil {

--- a/cmd/spantype/main.go
+++ b/cmd/spantype/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -50,9 +52,16 @@ func parseTypeAnnotationMode(s string) (spantype.TypeAnnotationMode, error) {
 }
 
 func run() error {
-	mode := flag.String("mode", "verbose", "format mode (simplest|simple|normal|verbose|more)")
-	typeAnn := flag.String("type-annotation", "suffix", "how to render TypeAnnotation: suffix|omit|primary")
-	flag.Parse()
+	fs := flag.NewFlagSet(filepath.Base(os.Args[0]), flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	mode := fs.String("mode", "verbose", "format mode (simplest|simple|normal|verbose|more)")
+	typeAnn := fs.String("type-annotation", "suffix", "how to render TypeAnnotation: suffix|omit|primary")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
 
 	formatOpt, err := modeToFormatOption(*mode)
 	if err != nil {

--- a/format.go
+++ b/format.go
@@ -1,5 +1,7 @@
 // Package spantype formats Cloud Spanner google.spanner.v1.Type values with
 // multiple verbosity levels for logs, errors, and debugging output.
+// Dialect [sppb.Type.TypeAnnotation] values (for example PostgreSQL PG_NUMERIC) are
+// controlled by [TypeAnnotationMode] inside [FormatOption].
 package spantype
 
 import (
@@ -69,18 +71,35 @@ const (
 	UnknownModePanic
 )
 
+// TypeAnnotationMode controls how [sppb.Type.TypeAnnotation] is rendered for simple
+// and container types (recursively for ARRAY and STRUCT fields).
+type TypeAnnotationMode int
+
+const (
+	// TypeAnnotationModeSuffix is the default (zero value): append a parenthetical
+	// annotation when set, e.g. `NUMERIC(PG_NUMERIC)`.
+	TypeAnnotationModeSuffix TypeAnnotationMode = iota
+	// TypeAnnotationModeOmit ignores TypeAnnotation and formats the base type only, e.g. `NUMERIC`.
+	TypeAnnotationModeOmit
+	// TypeAnnotationModePrimary uses the annotation as the displayed type label when non-UNSPECIFIED,
+	// e.g. `PG_NUMERIC` instead of `NUMERIC` or `NUMERIC(PG_NUMERIC)`.
+	TypeAnnotationModePrimary
+)
+
 // FormatOption is an option for FormatType, and FormatStructFields.
 type FormatOption struct {
 	// Struct controls STRUCT formatting.
-	Struct  StructMode
+	Struct StructMode
 	// Proto controls PROTO formatting.
-	Proto   ProtoEnumMode
+	Proto ProtoEnumMode
 	// Enum controls ENUM formatting.
-	Enum    ProtoEnumMode
+	Enum ProtoEnumMode
 	// Array controls ARRAY formatting.
-	Array   ArrayMode
+	Array ArrayMode
 	// Unknown controls formatting for unknown type codes.
 	Unknown UnknownMode
+	// TypeAnnotation controls how dialect TypeAnnotation is combined with the base type.
+	TypeAnnotation TypeAnnotationMode
 }
 
 var (
@@ -141,10 +160,22 @@ func formatTypeAnnotationSuffix(ann sppb.TypeAnnotationCode) string {
 }
 
 // FormatType formats Cloud Spanner type using the given FormatOption.
-// When [sppb.Type.TypeAnnotation] is set (e.g. PostgreSQL PG_NUMERIC / PG_JSONB), it is appended
-// as a parenthetical suffix on the formatted type, e.g. `NUMERIC(PG_NUMERIC)`.
+// [FormatOption.TypeAnnotation] selects whether [sppb.Type.TypeAnnotation] is omitted, appended
+// in parentheses after the base type, or used as the primary label (see [TypeAnnotationMode]).
 func FormatType(typ *sppb.Type, opts FormatOption) string {
-	return formatTypeImpl(typ, opts) + formatTypeAnnotationSuffix(typ.GetTypeAnnotation())
+	ann := typ.GetTypeAnnotation()
+	base := formatTypeImpl(typ, opts)
+	switch opts.TypeAnnotation {
+	case TypeAnnotationModeOmit:
+		return base
+	case TypeAnnotationModePrimary:
+		if ann == sppb.TypeAnnotationCode_TYPE_ANNOTATION_CODE_UNSPECIFIED {
+			return base
+		}
+		return ann.String()
+	default:
+		return base + formatTypeAnnotationSuffix(ann)
+	}
 }
 
 func formatTypeImpl(typ *sppb.Type, opts FormatOption) string {

--- a/format.go
+++ b/format.go
@@ -168,17 +168,16 @@ func formatTypeAnnotationSuffix(ann sppb.TypeAnnotationCode) string {
 // in parentheses after the base type, or used as the primary label (see [TypeAnnotationMode]).
 func FormatType(typ *sppb.Type, opts FormatOption) string {
 	ann := typ.GetTypeAnnotation()
-	base := formatTypeImpl(typ, opts)
 	switch opts.TypeAnnotation {
 	case TypeAnnotationModeOmit:
-		return base
+		return formatTypeImpl(typ, opts)
 	case TypeAnnotationModePrimary:
-		if ann == sppb.TypeAnnotationCode_TYPE_ANNOTATION_CODE_UNSPECIFIED {
-			return base
+		if ann != sppb.TypeAnnotationCode_TYPE_ANNOTATION_CODE_UNSPECIFIED {
+			return ann.String()
 		}
-		return ann.String()
+		return formatTypeImpl(typ, opts)
 	default:
-		return base + formatTypeAnnotationSuffix(ann)
+		return formatTypeImpl(typ, opts) + formatTypeAnnotationSuffix(ann)
 	}
 }
 

--- a/format.go
+++ b/format.go
@@ -87,6 +87,10 @@ const (
 )
 
 // FormatOption is an option for FormatType, and FormatStructFields.
+//
+// Callers building their own values should use keyed struct literals (e.g.
+// FormatOption{Struct: ..., Proto: ...}) so that new fields can be added in
+// minor releases without breaking compilation. Positional literals are fragile.
 type FormatOption struct {
 	// Struct controls STRUCT formatting.
 	Struct StructMode

--- a/format.go
+++ b/format.go
@@ -133,8 +133,21 @@ func lastCut(s, sep string) (before string, after string, found bool) {
 	return "", s, false
 }
 
+func formatTypeAnnotationSuffix(ann sppb.TypeAnnotationCode) string {
+	if ann == sppb.TypeAnnotationCode_TYPE_ANNOTATION_CODE_UNSPECIFIED {
+		return ""
+	}
+	return "(" + ann.String() + ")"
+}
+
 // FormatType formats Cloud Spanner type using the given FormatOption.
+// When [sppb.Type.TypeAnnotation] is set (e.g. PostgreSQL PG_NUMERIC / PG_JSONB), it is appended
+// as a parenthetical suffix on the formatted type, e.g. `NUMERIC(PG_NUMERIC)`.
 func FormatType(typ *sppb.Type, opts FormatOption) string {
+	return formatTypeImpl(typ, opts) + formatTypeAnnotationSuffix(typ.GetTypeAnnotation())
+}
+
+func formatTypeImpl(typ *sppb.Type, opts FormatOption) string {
 	code := typ.GetCode()
 	switch code {
 	case sppb.TypeCode_ARRAY:

--- a/format_test.go
+++ b/format_test.go
@@ -277,6 +277,46 @@ func TestFormatProtoEnum(t *testing.T) {
 	}
 }
 
+func TestFormatType_PostgreSQLAnnotations(t *testing.T) {
+	for _, tt := range []struct {
+		desc string
+		typ  *sppb.Type
+		want string
+	}{
+		{
+			desc: "NUMERIC PG_NUMERIC",
+			typ:  PGNumeric(),
+			want: "NUMERIC(PG_NUMERIC)",
+		},
+		{
+			desc: "JSON PG_JSONB",
+			typ:  PGJsonB(),
+			want: "JSON(PG_JSONB)",
+		},
+		{
+			desc: "INT64 PG_OID",
+			typ:  PGOid(),
+			want: "INT64(PG_OID)",
+		},
+		{
+			desc: "ARRAY<NUMERIC PG_NUMERIC>",
+			typ:  ElemTypeToArrayType(PGNumeric()),
+			want: "ARRAY<NUMERIC(PG_NUMERIC)>",
+		},
+		{
+			desc: "STRUCT with PG annotations (normal mode omits field names)",
+			typ:  MustNameTypeSlicesToStructType([]string{"a", "b"}, []*sppb.Type{PGNumeric(), PGJsonB()}),
+			want: "STRUCT<NUMERIC(PG_NUMERIC), JSON(PG_JSONB)>",
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := FormatTypeNormal(tt.typ); got != tt.want {
+				t.Errorf("FormatTypeNormal want %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestFormatTypeCode(t *testing.T) {
 	tests := []struct {
 		desc        string

--- a/format_test.go
+++ b/format_test.go
@@ -278,6 +278,7 @@ func TestFormatProtoEnum(t *testing.T) {
 }
 
 func TestFormatType_PostgreSQLAnnotations(t *testing.T) {
+	normal := FormatOptionNormal
 	for _, tt := range []struct {
 		desc string
 		typ  *sppb.Type
@@ -310,11 +311,48 @@ func TestFormatType_PostgreSQLAnnotations(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got := FormatTypeNormal(tt.typ); got != tt.want {
-				t.Errorf("FormatTypeNormal want %q, got %q", tt.want, got)
+			if got := FormatType(tt.typ, normal); got != tt.want {
+				t.Errorf("FormatType(FormatOptionNormal) want %q, got %q", tt.want, got)
 			}
 		})
 	}
+}
+
+func TestFormatType_TypeAnnotationMode(t *testing.T) {
+	typ := PGNumeric()
+	opts := FormatOptionNormal
+
+	t.Run("Suffix is default zero value", func(t *testing.T) {
+		var empty FormatOption
+		if got := FormatType(typ, empty); got != "NUMERIC(PG_NUMERIC)" {
+			t.Errorf("zero FormatOption want NUMERIC(PG_NUMERIC), got %q", got)
+		}
+	})
+
+	t.Run("Omit", func(t *testing.T) {
+		o := opts
+		o.TypeAnnotation = TypeAnnotationModeOmit
+		if got := FormatType(typ, o); got != "NUMERIC" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("Primary", func(t *testing.T) {
+		o := opts
+		o.TypeAnnotation = TypeAnnotationModePrimary
+		if got := FormatType(typ, o); got != "PG_NUMERIC" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("Primary ARRAY element", func(t *testing.T) {
+		o := opts
+		o.TypeAnnotation = TypeAnnotationModePrimary
+		arr := ElemTypeToArrayType(PGNumeric())
+		if got := FormatType(arr, o); got != "ARRAY<PG_NUMERIC>" {
+			t.Errorf("got %q", got)
+		}
+	})
 }
 
 func TestFormatTypeCode(t *testing.T) {

--- a/format_test.go
+++ b/format_test.go
@@ -324,24 +324,27 @@ func TestFormatType_TypeAnnotationMode(t *testing.T) {
 
 	t.Run("Suffix is default zero value", func(t *testing.T) {
 		var empty FormatOption
-		if got := FormatType(typ, empty); got != "NUMERIC(PG_NUMERIC)" {
-			t.Errorf("zero FormatOption want NUMERIC(PG_NUMERIC), got %q", got)
+		const want = "NUMERIC(PG_NUMERIC)"
+		if got := FormatType(typ, empty); got != want {
+			t.Errorf("FormatType zero FormatOption: want %q, got %q", want, got)
 		}
 	})
 
 	t.Run("Omit", func(t *testing.T) {
 		o := opts
 		o.TypeAnnotation = TypeAnnotationModeOmit
-		if got := FormatType(typ, o); got != "NUMERIC" {
-			t.Errorf("got %q", got)
+		const want = "NUMERIC"
+		if got := FormatType(typ, o); got != want {
+			t.Errorf("FormatType Omit: want %q, got %q", want, got)
 		}
 	})
 
 	t.Run("Primary", func(t *testing.T) {
 		o := opts
 		o.TypeAnnotation = TypeAnnotationModePrimary
-		if got := FormatType(typ, o); got != "PG_NUMERIC" {
-			t.Errorf("got %q", got)
+		const want = "PG_NUMERIC"
+		if got := FormatType(typ, o); got != want {
+			t.Errorf("FormatType Primary: want %q, got %q", want, got)
 		}
 	})
 
@@ -349,8 +352,9 @@ func TestFormatType_TypeAnnotationMode(t *testing.T) {
 		o := opts
 		o.TypeAnnotation = TypeAnnotationModePrimary
 		arr := ElemTypeToArrayType(PGNumeric())
-		if got := FormatType(arr, o); got != "ARRAY<PG_NUMERIC>" {
-			t.Errorf("got %q", got)
+		const want = "ARRAY<PG_NUMERIC>"
+		if got := FormatType(arr, o); got != want {
+			t.Errorf("FormatType Primary ARRAY: want %q, got %q", want, got)
 		}
 	})
 }

--- a/format_test.go
+++ b/format_test.go
@@ -291,12 +291,12 @@ func TestFormatType_PostgreSQLAnnotations(t *testing.T) {
 		},
 		{
 			desc: "JSON PG_JSONB",
-			typ:  PGJsonB(),
+			typ:  PGJSONB(),
 			want: "JSON(PG_JSONB)",
 		},
 		{
 			desc: "INT64 PG_OID",
-			typ:  PGOid(),
+			typ:  PGOID(),
 			want: "INT64(PG_OID)",
 		},
 		{
@@ -306,7 +306,7 @@ func TestFormatType_PostgreSQLAnnotations(t *testing.T) {
 		},
 		{
 			desc: "STRUCT with PG annotations (normal mode omits field names)",
-			typ:  MustNameTypeSlicesToStructType([]string{"a", "b"}, []*sppb.Type{PGNumeric(), PGJsonB()}),
+			typ:  MustNameTypeSlicesToStructType([]string{"a", "b"}, []*sppb.Type{PGNumeric(), PGJSONB()}),
 			want: "STRUCT<NUMERIC(PG_NUMERIC), JSON(PG_JSONB)>",
 		},
 	} {

--- a/typector/typector.go
+++ b/typector/typector.go
@@ -1,7 +1,7 @@
 // Package typector provides small constructor helpers for building Cloud
 // Spanner google.spanner.v1.Type values and struct fields in tests and callers.
 // PostgreSQL-oriented types use [sppb.Type.TypeAnnotation]; see [SimpleTypeWithAnnotation],
-// [PGNumeric], [PGJsonB], and [PGOid].
+// [PGNumeric], [PGJSONB], and [PGOID].
 package typector
 
 import (
@@ -66,13 +66,13 @@ func PGNumeric() *sppb.Type {
 	return SimpleTypeWithAnnotation(sppb.TypeCode_NUMERIC, sppb.TypeAnnotationCode_PG_NUMERIC)
 }
 
-// PGJsonB returns a JSON type with PostgreSQL [sppb.TypeAnnotationCode_PG_JSONB] semantics.
-func PGJsonB() *sppb.Type {
+// PGJSONB returns a JSON type with PostgreSQL [sppb.TypeAnnotationCode_PG_JSONB] semantics.
+func PGJSONB() *sppb.Type {
 	return SimpleTypeWithAnnotation(sppb.TypeCode_JSON, sppb.TypeAnnotationCode_PG_JSONB)
 }
 
-// PGOid returns an INT64 type with PostgreSQL [sppb.TypeAnnotationCode_PG_OID] semantics.
-func PGOid() *sppb.Type {
+// PGOID returns an INT64 type with PostgreSQL [sppb.TypeAnnotationCode_PG_OID] semantics.
+func PGOID() *sppb.Type {
 	return SimpleTypeWithAnnotation(sppb.TypeCode_INT64, sppb.TypeAnnotationCode_PG_OID)
 }
 

--- a/typector/typector.go
+++ b/typector/typector.go
@@ -53,6 +53,27 @@ func CodeToSimpleType(code sppb.TypeCode) *sppb.Type {
 	return &sppb.Type{Code: code}
 }
 
+// SimpleTypeWithAnnotation returns a simple type with the given code and optional
+// [sppb.Type.TypeAnnotation] (use [sppb.TypeAnnotationCode_TYPE_ANNOTATION_CODE_UNSPECIFIED] for none).
+func SimpleTypeWithAnnotation(code sppb.TypeCode, ann sppb.TypeAnnotationCode) *sppb.Type {
+	return &sppb.Type{Code: code, TypeAnnotation: ann}
+}
+
+// PGNumeric returns a NUMERIC type with PostgreSQL [sppb.TypeAnnotationCode_PG_NUMERIC] semantics.
+func PGNumeric() *sppb.Type {
+	return SimpleTypeWithAnnotation(sppb.TypeCode_NUMERIC, sppb.TypeAnnotationCode_PG_NUMERIC)
+}
+
+// PGJsonB returns a JSON type with PostgreSQL [sppb.TypeAnnotationCode_PG_JSONB] semantics.
+func PGJsonB() *sppb.Type {
+	return SimpleTypeWithAnnotation(sppb.TypeCode_JSON, sppb.TypeAnnotationCode_PG_JSONB)
+}
+
+// PGOid returns an INT64 type with PostgreSQL [sppb.TypeAnnotationCode_PG_OID] semantics.
+func PGOid() *sppb.Type {
+	return SimpleTypeWithAnnotation(sppb.TypeCode_INT64, sppb.TypeAnnotationCode_PG_OID)
+}
+
 // ElemCodeToArrayType returns an ARRAY type with the given element type code.
 func ElemCodeToArrayType(code sppb.TypeCode) *sppb.Type {
 	return ElemTypeToArrayType(CodeToSimpleType(code))

--- a/typector/typector.go
+++ b/typector/typector.go
@@ -1,5 +1,7 @@
 // Package typector provides small constructor helpers for building Cloud
 // Spanner google.spanner.v1.Type values and struct fields in tests and callers.
+// PostgreSQL-oriented types use [sppb.Type.TypeAnnotation]; see [SimpleTypeWithAnnotation],
+// [PGNumeric], [PGJsonB], and [PGOid].
 package typector
 
 import (


### PR DESCRIPTION
## Summary

- **`FormatType`**: Append dialect [`TypeAnnotation`](https://pkg.go.dev/cloud.google.com/go/spanner/apiv1/spannerpb#Type) via [`FormatOption.TypeAnnotation`](https://pkg.go.dev/github.com/apstndb/spantype#FormatOption): **Suffix** (default, `NUMERIC(PG_NUMERIC)`), **Omit**, or **Primary** (`PG_NUMERIC`).
- **`typector`**: [`SimpleTypeWithAnnotation`](https://pkg.go.dev/github.com/apstndb/spantype/typector#SimpleTypeWithAnnotation), [`PGNumeric`](https://pkg.go.dev/github.com/apstndb/spantype/typector#PGNumeric), [`PGJsonB`](https://pkg.go.dev/github.com/apstndb/spantype/typector#PGJsonB), [`PGOid`](https://pkg.go.dev/github.com/apstndb/spantype/typector#PGOid).
- **`cmd/spantype`**: `--type-annotation=suffix|omit|primary`; unknown flags return an error instead of panicking.
- **Docs**: README updates for modes and CLI.

Labels use protobuf / Spanner vocabulary (`PG_*`), not PostgreSQL catalog spellings.

Closes #8

Made with [Cursor](https://cursor.com)