### PR TITLE
Add FormatTypePostgreSQL, PostgreSQL-dialect type spellings

### DIFF
--- a/format_postgresql.go
+++ b/format_postgresql.go
@@ -1,0 +1,130 @@
+package spantype
+
+import (
+	"fmt"
+	"strings"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+)
+
+// FormatTypePostgreSQL renders a [sppb.Type] using PostgreSQL-dialect
+// spellings from
+// https://docs.cloud.google.com/spanner/docs/reference/postgresql/data-types
+// (supported types: bool, bytea, date, float4, float8, bigint, interval,
+// jsonb, numeric, timestamptz, text, uuid, oid, and `T[]` array
+// declarations). [sppb.TypeCode_JSON] is rendered "jsonb" only when the type
+// carries [sppb.TypeAnnotationCode_PG_JSONB] (otherwise "json", a label that
+// preserves the wire distinction even though plain JSON is not a PostgreSQL
+// data type), and [sppb.TypeCode_INT64] with
+// [sppb.TypeAnnotationCode_PG_OID] is rendered "oid". A nil type renders as
+// the empty string.
+//
+// [sppb.TypeCode_PROTO] and [sppb.TypeCode_ENUM] are not
+// PostgreSQL-interface types: they render as "proto" and "enum" — not as
+// "bytea" or "text" — so wire types are never mislabeled if they appear in
+// metadata. [sppb.TypeCode_STRUCT] does not appear in PostgreSQL-dialect
+// metadata in practice today; the provisional rendering uses GoogleSQL
+// STRUCT<...> declaration syntax with field types spelled using the
+// PostgreSQL names above, and may change once official guidance for
+// composite types exists (no stability guarantee for the STRUCT branch).
+//
+// This function originated as FormatPostgreSQLType in
+// github.com/apstndb/spanpg, where its spellings are pinned against
+// PostgreSQL-dialect Spanner databases by integration probes.
+func FormatTypePostgreSQL(typ *sppb.Type) string {
+	if typ == nil {
+		return ""
+	}
+	return formatTypePostgreSQLImpl(typ)
+}
+
+func formatTypePostgreSQLImpl(typ *sppb.Type) string {
+	switch typ.GetCode() {
+	case sppb.TypeCode_ARRAY:
+		elem := typ.GetArrayElementType()
+		if elem == nil {
+			return "array/*nil element type*/"
+		}
+		return formatTypePostgreSQLImpl(elem) + "[]"
+
+	case sppb.TypeCode_STRUCT:
+		// Provisional: PG dialect rarely exposes STRUCT today; see FormatTypePostgreSQL godoc.
+		fields := typ.GetStructType().GetFields()
+		if len(fields) == 0 {
+			return "STRUCT<>"
+		}
+		return "STRUCT<" + formatStructFieldsWith(fields, formatTypePostgreSQLImpl) + ">"
+
+	case sppb.TypeCode_BOOL:
+		return "bool"
+
+	case sppb.TypeCode_INT64:
+		if typ.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_OID {
+			return "oid"
+		}
+		return "bigint"
+
+	case sppb.TypeCode_FLOAT32:
+		return "float4"
+
+	case sppb.TypeCode_FLOAT64:
+		return "float8"
+
+	case sppb.TypeCode_STRING:
+		return "text"
+
+	case sppb.TypeCode_BYTES:
+		return "bytea"
+
+	case sppb.TypeCode_TIMESTAMP:
+		return "timestamptz"
+
+	case sppb.TypeCode_DATE:
+		return "date"
+
+	case sppb.TypeCode_NUMERIC:
+		return "numeric"
+
+	case sppb.TypeCode_JSON:
+		if typ.GetTypeAnnotation() == sppb.TypeAnnotationCode_PG_JSONB {
+			return "jsonb"
+		}
+		return "json"
+
+	case sppb.TypeCode_INTERVAL:
+		return "interval"
+
+	case sppb.TypeCode_UUID:
+		return "uuid"
+
+	case sppb.TypeCode_PROTO:
+		return "proto"
+
+	case sppb.TypeCode_ENUM:
+		return "enum"
+
+	case sppb.TypeCode_TYPE_CODE_UNSPECIFIED:
+		return "unknown"
+
+	default:
+		return fmt.Sprintf("unknown(%d)", typ.GetCode())
+	}
+}
+
+// formatStructFieldsWith joins STRUCT fields as `name type, ...` (unnamed
+// fields render the type only), spelling each field type with format.
+// Unlike [FormatStructFields] it always shows available field names.
+func formatStructFieldsWith(fields []*sppb.StructType_Field, format func(*sppb.Type) string) string {
+	var b strings.Builder
+	for i, f := range fields {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		if n := f.GetName(); n != "" {
+			b.WriteString(n)
+			b.WriteByte(' ')
+		}
+		b.WriteString(format(f.GetType()))
+	}
+	return b.String()
+}

--- a/format_postgresql.go
+++ b/format_postgresql.go
@@ -39,6 +39,11 @@ func FormatTypePostgreSQL(typ *sppb.Type) string {
 }
 
 func formatTypePostgreSQLImpl(typ *sppb.Type) string {
+	// Recursive positions (array elements, struct field types) may pass nil;
+	// the explicit check keeps the behavior independent of getter nil-safety.
+	if typ == nil {
+		return "unknown"
+	}
 	switch typ.GetCode() {
 	case sppb.TypeCode_ARRAY:
 		elem := typ.GetArrayElementType()

--- a/format_postgresql_test.go
+++ b/format_postgresql_test.go
@@ -1,0 +1,77 @@
+package spantype_test
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+
+	"github.com/apstndb/spantype"
+	"github.com/apstndb/spantype/typector"
+)
+
+func pgType(code sppb.TypeCode, ann sppb.TypeAnnotationCode) *sppb.Type {
+	return &sppb.Type{Code: code, TypeAnnotation: ann}
+}
+
+func TestFormatTypePostgreSQL(t *testing.T) {
+	t.Parallel()
+
+	none := sppb.TypeAnnotationCode_TYPE_ANNOTATION_CODE_UNSPECIFIED
+	tests := []struct {
+		desc string
+		typ  *sppb.Type
+		want string
+	}{
+		{"nil", nil, ""},
+		{"bool", pgType(sppb.TypeCode_BOOL, none), "bool"},
+		{"bigint", pgType(sppb.TypeCode_INT64, none), "bigint"},
+		{"oid", pgType(sppb.TypeCode_INT64, sppb.TypeAnnotationCode_PG_OID), "oid"},
+		{"float4", pgType(sppb.TypeCode_FLOAT32, none), "float4"},
+		{"float8", pgType(sppb.TypeCode_FLOAT64, none), "float8"},
+		{"text", pgType(sppb.TypeCode_STRING, none), "text"},
+		{"bytea", pgType(sppb.TypeCode_BYTES, none), "bytea"},
+		{"timestamptz", pgType(sppb.TypeCode_TIMESTAMP, none), "timestamptz"},
+		{"date", pgType(sppb.TypeCode_DATE, none), "date"},
+		{"numeric plain", pgType(sppb.TypeCode_NUMERIC, none), "numeric"},
+		{"numeric pg annotation", pgType(sppb.TypeCode_NUMERIC, sppb.TypeAnnotationCode_PG_NUMERIC), "numeric"},
+		{"jsonb", pgType(sppb.TypeCode_JSON, sppb.TypeAnnotationCode_PG_JSONB), "jsonb"},
+		{"plain json keeps the wire distinction", pgType(sppb.TypeCode_JSON, none), "json"},
+		{"interval", pgType(sppb.TypeCode_INTERVAL, none), "interval"},
+		{"uuid", pgType(sppb.TypeCode_UUID, none), "uuid"},
+		{"proto never mislabeled", pgType(sppb.TypeCode_PROTO, none), "proto"},
+		{"enum never mislabeled", pgType(sppb.TypeCode_ENUM, none), "enum"},
+		{"unspecified", pgType(sppb.TypeCode_TYPE_CODE_UNSPECIFIED, none), "unknown"},
+		{"unknown code", pgType(sppb.TypeCode(9999), none), "unknown(9999)"},
+		{"array", typector.ElemCodeToArrayType(sppb.TypeCode_INT64), "bigint[]"},
+		{"array of jsonb", typector.ElemTypeToArrayType(pgType(sppb.TypeCode_JSON, sppb.TypeAnnotationCode_PG_JSONB)), "jsonb[]"},
+		{"nested array", typector.ElemTypeToArrayType(typector.ElemCodeToArrayType(sppb.TypeCode_STRING)), "text[][]"},
+		{"array with nil element type", &sppb.Type{Code: sppb.TypeCode_ARRAY}, "array/*nil element type*/"},
+		{"empty struct", &sppb.Type{Code: sppb.TypeCode_STRUCT, StructType: &sppb.StructType{}}, "STRUCT<>"},
+		{
+			"struct with named and unnamed fields",
+			typector.StructTypeFieldsToStructType([]*sppb.StructType_Field{
+				typector.NameCodeToStructTypeField("x", sppb.TypeCode_INT64),
+				{Type: pgType(sppb.TypeCode_STRING, none)},
+			}),
+			"STRUCT<x bigint, text>",
+		},
+		{
+			"nested struct",
+			typector.StructTypeFieldsToStructType([]*sppb.StructType_Field{
+				typector.NameTypeToStructTypeField("inner", typector.StructTypeFieldsToStructType([]*sppb.StructType_Field{
+					typector.NameCodeToStructTypeField("x", sppb.TypeCode_INT64),
+					typector.NameCodeToStructTypeField("y", sppb.TypeCode_STRING),
+				})),
+			}),
+			"STRUCT<inner STRUCT<x bigint, y text>>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := spantype.FormatTypePostgreSQL(tt.typ); got != tt.want {
+				t.Errorf("FormatTypePostgreSQL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moves the PostgreSQL-dialect spelling table from github.com/apstndb/spanpg into the layer every type-rendering consumer already depends on:

- spannersh renders PG headers via `spanpg.FormatPostgreSQLType` today and pays the spanpg dependency only for it; spanvalue/spancodec cannot depend on spanpg without inverting the dialect-adapter layering, so the option of dialect spellings at those layers only exists here.
- spanpg will keep `FormatPostgreSQLType` as a deprecated alias delegating to this function until its next breaking release, and its `integration/pgtypeannotation` probes (which execute the spellings against PG-dialect Spanner databases) continue to pin the behavior end to end.

Design note: this joins the `FormatType<Variant>` family as a self-contained formatter rather than a new `FormatOption` axis — the existing axes (Struct/Proto/Enum/Array/Unknown/TypeAnnotation) parametrize structure, while a dialect swaps the scalar spelling table, the array syntax (`T[]`), proto/enum casing, and annotation interpretation all at once. Folding dialects into `FormatOption` is deferred until a second dialect appears. Behavior is identical to the spanpg original (tests ported and extended: PG_OID, annotated vs plain NUMERIC/JSON, nested arrays/structs, unnamed fields, nil/unknown codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)