### PR TITLE
Add EquivalentTypes for Spanner type metadata comparison

### DIFF
--- a/equivalent.go
+++ b/equivalent.go
@@ -27,9 +27,15 @@ import (
 // gcvctor.WithEquivalentType.
 func EquivalentTypes(a, b *sppb.Type) bool {
 	if a == nil || b == nil {
-		return a == nil && b == nil
+		return a == b
 	}
 	if a.GetCode() != b.GetCode() {
+		return false
+	}
+	if a.GetTypeAnnotation() != b.GetTypeAnnotation() {
+		return false
+	}
+	if a.GetProtoTypeFqn() != b.GetProtoTypeFqn() {
 		return false
 	}
 	switch a.GetCode() {
@@ -39,7 +45,7 @@ func EquivalentTypes(a, b *sppb.Type) bool {
 		aStruct := a.GetStructType()
 		bStruct := b.GetStructType()
 		if aStruct == nil || bStruct == nil {
-			return aStruct == nil && bStruct == nil
+			return aStruct == bStruct
 		}
 		aFields := aStruct.GetFields()
 		bFields := bStruct.GetFields()

--- a/equivalent.go
+++ b/equivalent.go
@@ -5,11 +5,26 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// EquivalentTypes reports whether a and b are Spanner-equivalent type metadata.
-// Scalar types require proto.Equal metadata. ARRAY types require equivalent
-// element types. STRUCT types require the same number of fields with pairwise
-// equivalent field types; field names are not compared. This matches identity
-// CAST and ARRAY cast equivalence in GoogleSQL semantic layers.
+// EquivalentTypes reports whether a and b are Spanner-equivalent [cloud.google.com/go/spanner/apiv1/spannerpb.Type]
+// metadata for identity retyping: a value of either type can carry the same wire
+// payload when only Type metadata differs.
+//
+// Rules follow [google.spanner.v1.Type] shape
+// (https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/type.proto)
+// and GoogleSQL supertypes for composite types
+// (https://docs.cloud.google.com/spanner/docs/reference/standard-sql/conversion_rules#supertypes):
+//
+//   - Scalars: proto.Equal, including [sppb.Type.TypeAnnotation] and
+//     [sppb.Type.ProtoTypeFqn] for PROTO and ENUM.
+//   - ARRAY: equivalent [sppb.Type.ArrayElementType].
+//   - STRUCT: same number of fields with pairwise equivalent field types by
+//     position; field names are not compared.
+//
+// This is narrower than the Cast table in the same conversion-rules page:
+// types that can CAST to one another (for example INT64 and FLOAT64) are not
+// necessarily equivalent. Use EquivalentTypes only when semantics require an
+// identity path (no value conversion), such as ARRAY/STRUCT layout checks or
+// gcvctor.WithEquivalentType.
 func EquivalentTypes(a, b *sppb.Type) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil

--- a/equivalent.go
+++ b/equivalent.go
@@ -6,18 +6,22 @@ import (
 
 // EquivalentTypes reports whether a and b are Spanner-equivalent [cloud.google.com/go/spanner/apiv1/spannerpb.Type]
 // metadata for identity retyping: a value of either type can carry the same wire
-// payload when only Type metadata differs.
+// payload when only Type metadata differs in ways that do not affect type identity.
+//
+// EquivalentTypes is stricter than wire-encoding compatibility: [sppb.Type.TypeAnnotation]
+// and [sppb.Type.ProtoTypeFqn] are part of type identity even when serialization is
+// unchanged.
 //
 // Rules follow [google.spanner.v1.Type] shape
 // (https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/type.proto)
 // and GoogleSQL supertypes for composite types
 // (https://docs.cloud.google.com/spanner/docs/reference/standard-sql/conversion_rules#supertypes):
 //
-//   - Scalars: proto.Equal, including [sppb.Type.TypeAnnotation] and
-//     [sppb.Type.ProtoTypeFqn] for PROTO and ENUM.
-//   - ARRAY: equivalent [sppb.Type.ArrayElementType].
+//   - Scalars: same TypeCode, TypeAnnotation, and ProtoTypeFqn; container fields
+//     must be absent. Unknown protobuf fields are intentionally ignored.
+//   - ARRAY: equivalent [sppb.Type.ArrayElementType]; [sppb.Type.StructType] must be absent.
 //   - STRUCT: same number of fields with pairwise equivalent field types by
-//     position; field names are not compared.
+//     position; field names are not compared. [sppb.Type.ArrayElementType] must be absent.
 //
 // This is narrower than the Cast table in the same conversion-rules page:
 // types that can CAST to one another (for example INT64 and FLOAT64) are not
@@ -31,6 +35,9 @@ func EquivalentTypes(a, b *sppb.Type) bool {
 	if a.GetCode() != b.GetCode() {
 		return false
 	}
+	if a.GetCode() == sppb.TypeCode_TYPE_CODE_UNSPECIFIED {
+		return false
+	}
 	if a.GetTypeAnnotation() != b.GetTypeAnnotation() {
 		return false
 	}
@@ -39,12 +46,21 @@ func EquivalentTypes(a, b *sppb.Type) bool {
 	}
 	switch a.GetCode() {
 	case sppb.TypeCode_ARRAY:
+		if a.GetStructType() != nil || b.GetStructType() != nil {
+			return false
+		}
+		if a.GetArrayElementType() == nil || b.GetArrayElementType() == nil {
+			return false
+		}
 		return EquivalentTypes(a.GetArrayElementType(), b.GetArrayElementType())
 	case sppb.TypeCode_STRUCT:
+		if a.GetArrayElementType() != nil || b.GetArrayElementType() != nil {
+			return false
+		}
 		aStruct := a.GetStructType()
 		bStruct := b.GetStructType()
 		if aStruct == nil || bStruct == nil {
-			return aStruct == bStruct
+			return false
 		}
 		aFields := aStruct.GetFields()
 		bFields := bStruct.GetFields()
@@ -63,10 +79,10 @@ func EquivalentTypes(a, b *sppb.Type) bool {
 			}
 		}
 		return true
-	default:
-		// Code, TypeAnnotation, and ProtoTypeFqn already match. For scalar
-		// codes, reject malformed container fields without proto.Equal so
-		// unknown protobuf fields from newer servers do not break identity checks.
+	case sppb.TypeCode_PROTO, sppb.TypeCode_ENUM:
+		if a.GetProtoTypeFqn() == "" {
+			return false
+		}
 		if a.GetArrayElementType() != nil || b.GetArrayElementType() != nil {
 			return false
 		}
@@ -74,5 +90,26 @@ func EquivalentTypes(a, b *sppb.Type) bool {
 			return false
 		}
 		return true
+	case sppb.TypeCode_BOOL,
+		sppb.TypeCode_INT64,
+		sppb.TypeCode_FLOAT64,
+		sppb.TypeCode_FLOAT32,
+		sppb.TypeCode_TIMESTAMP,
+		sppb.TypeCode_DATE,
+		sppb.TypeCode_STRING,
+		sppb.TypeCode_BYTES,
+		sppb.TypeCode_NUMERIC,
+		sppb.TypeCode_JSON,
+		sppb.TypeCode_INTERVAL,
+		sppb.TypeCode_UUID:
+		if a.GetArrayElementType() != nil || b.GetArrayElementType() != nil {
+			return false
+		}
+		if a.GetStructType() != nil || b.GetStructType() != nil {
+			return false
+		}
+		return true
+	default:
+		return false
 	}
 }

--- a/equivalent.go
+++ b/equivalent.go
@@ -1,0 +1,49 @@
+package spantype
+
+import (
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/proto"
+)
+
+// EquivalentTypes reports whether a and b are Spanner-equivalent type metadata.
+// Scalar types require proto.Equal metadata. ARRAY types require equivalent
+// element types. STRUCT types require the same number of fields with pairwise
+// equivalent field types; field names are not compared. This matches identity
+// CAST and ARRAY cast equivalence in GoogleSQL semantic layers.
+func EquivalentTypes(a, b *sppb.Type) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.GetCode() != b.GetCode() {
+		return false
+	}
+	switch a.GetCode() {
+	case sppb.TypeCode_ARRAY:
+		return EquivalentTypes(a.GetArrayElementType(), b.GetArrayElementType())
+	case sppb.TypeCode_STRUCT:
+		aStruct := a.GetStructType()
+		bStruct := b.GetStructType()
+		if aStruct == nil || bStruct == nil {
+			return aStruct == nil && bStruct == nil
+		}
+		aFields := aStruct.GetFields()
+		bFields := bStruct.GetFields()
+		if len(aFields) != len(bFields) {
+			return false
+		}
+		for i := range aFields {
+			if aFields[i] == nil || bFields[i] == nil {
+				if aFields[i] != bFields[i] {
+					return false
+				}
+				continue
+			}
+			if !EquivalentTypes(aFields[i].GetType(), bFields[i].GetType()) {
+				return false
+			}
+		}
+		return true
+	default:
+		return proto.Equal(a, b)
+	}
+}

--- a/equivalent.go
+++ b/equivalent.go
@@ -2,7 +2,6 @@ package spantype
 
 import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"google.golang.org/protobuf/proto"
 )
 
 // EquivalentTypes reports whether a and b are Spanner-equivalent [cloud.google.com/go/spanner/apiv1/spannerpb.Type]
@@ -65,6 +64,15 @@ func EquivalentTypes(a, b *sppb.Type) bool {
 		}
 		return true
 	default:
-		return proto.Equal(a, b)
+		// Code, TypeAnnotation, and ProtoTypeFqn already match. For scalar
+		// codes, reject malformed container fields without proto.Equal so
+		// unknown protobuf fields from newer servers do not break identity checks.
+		if a.GetArrayElementType() != nil || b.GetArrayElementType() != nil {
+			return false
+		}
+		if a.GetStructType() != nil || b.GetStructType() != nil {
+			return false
+		}
+		return true
 	}
 }

--- a/equivalent_test.go
+++ b/equivalent_test.go
@@ -22,6 +22,17 @@ func TestEquivalentTypesScalar(t *testing.T) {
 	}
 }
 
+func TestEquivalentTypesScalarSupertypesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
+	if spantype.EquivalentTypes(typector.Int64(), typector.Float64()) {
+		t.Fatalf("INT64 and FLOAT64 share a GoogleSQL supertype but are not identity-equivalent")
+	}
+	if spantype.EquivalentTypes(typector.Int64(), typector.Numeric()) {
+		t.Fatalf("INT64 and NUMERIC are coercible/supertypable but not identity-equivalent")
+	}
+}
+
 func TestEquivalentTypesArray(t *testing.T) {
 	t.Parallel()
 
@@ -30,6 +41,16 @@ func TestEquivalentTypesArray(t *testing.T) {
 	b := typector.ElemTypeToArrayType(typector.CodeToSimpleType(sppb.TypeCode_INT64))
 	if !spantype.EquivalentTypes(a, b) {
 		t.Fatalf("ARRAY<INT64> types should be equivalent")
+	}
+}
+
+func TestEquivalentTypesArrayNegative(t *testing.T) {
+	t.Parallel()
+
+	a := typector.ElemTypeToArrayType(typector.Int64())
+	b := typector.ElemTypeToArrayType(typector.String())
+	if spantype.EquivalentTypes(a, b) {
+		t.Fatalf("ARRAY<INT64> and ARRAY<STRING> should not be equivalent")
 	}
 }
 
@@ -44,6 +65,55 @@ func TestEquivalentTypesStructIgnoresFieldNames(t *testing.T) {
 	}
 	if !spantype.EquivalentTypes(a, b) {
 		t.Fatalf("EquivalentTypes should ignore field names")
+	}
+}
+
+func TestEquivalentTypesStructNegative(t *testing.T) {
+	t.Parallel()
+
+	t.Run("field type mismatch", func(t *testing.T) {
+		a := typector.NameTypeToStructType("a", typector.Int64())
+		b := typector.NameTypeToStructType("a", typector.String())
+		if spantype.EquivalentTypes(a, b) {
+			t.Fatalf("STRUCT with different field types should not be equivalent")
+		}
+	})
+
+	t.Run("field count mismatch", func(t *testing.T) {
+		a := typector.NameTypeToStructType("a", typector.Int64())
+		b := typector.MustNameCodeSlicesToStructType([]string{"a", "b"}, []sppb.TypeCode{
+			sppb.TypeCode_INT64,
+			sppb.TypeCode_INT64,
+		})
+		if spantype.EquivalentTypes(a, b) {
+			t.Fatalf("STRUCT with different field counts should not be equivalent")
+		}
+	})
+
+	t.Run("field order matters", func(t *testing.T) {
+		a := typector.MustNameCodeSlicesToStructType([]string{"a", "b"}, []sppb.TypeCode{
+			sppb.TypeCode_INT64,
+			sppb.TypeCode_STRING,
+		})
+		b := typector.MustNameCodeSlicesToStructType([]string{"a", "b"}, []sppb.TypeCode{
+			sppb.TypeCode_STRING,
+			sppb.TypeCode_INT64,
+		})
+		if spantype.EquivalentTypes(a, b) {
+			t.Fatalf("STRUCT field order should matter for equivalence")
+		}
+	})
+}
+
+func TestEquivalentTypesNestedArrayStructFieldNames(t *testing.T) {
+	t.Parallel()
+
+	innerA := typector.NameTypeToStructType("a", typector.Int64())
+	innerB := typector.NameTypeToStructType("b", typector.Int64())
+	a := typector.ElemTypeToArrayType(innerA)
+	b := typector.ElemTypeToArrayType(innerB)
+	if !spantype.EquivalentTypes(a, b) {
+		t.Fatalf("ARRAY<STRUCT> with different field names should be equivalent")
 	}
 }
 
@@ -91,4 +161,91 @@ func TestEquivalentTypesArrayContainerAnnotationMismatch(t *testing.T) {
 	if spantype.EquivalentTypes(a, b) {
 		t.Fatalf("ARRAY types with different container TypeAnnotation should not be equivalent")
 	}
+}
+
+func TestEquivalentTypesUnspecified(t *testing.T) {
+	t.Parallel()
+
+	unspecified := &sppb.Type{}
+	if spantype.EquivalentTypes(unspecified, unspecified) {
+		t.Fatalf("TYPE_CODE_UNSPECIFIED should not be equivalent")
+	}
+}
+
+func TestEquivalentTypesNilAndMalformed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil inputs", func(t *testing.T) {
+		if !spantype.EquivalentTypes(nil, nil) {
+			t.Error("nil types should be equivalent")
+		}
+		if spantype.EquivalentTypes(typector.Int64(), nil) {
+			t.Error("non-nil and nil types should not be equivalent")
+		}
+		if spantype.EquivalentTypes(nil, typector.Int64()) {
+			t.Error("nil and non-nil types should not be equivalent")
+		}
+	})
+
+	t.Run("malformed scalar container fields", func(t *testing.T) {
+		malformedScalar := &sppb.Type{
+			Code:             sppb.TypeCode_INT64,
+			ArrayElementType: typector.Int64(),
+		}
+		if spantype.EquivalentTypes(malformedScalar, typector.Int64()) {
+			t.Error("malformed scalar with ArrayElementType should not be equivalent to valid scalar")
+		}
+	})
+
+	t.Run("malformed array", func(t *testing.T) {
+		missingElem := &sppb.Type{Code: sppb.TypeCode_ARRAY}
+		validArray := typector.ElemTypeToArrayType(typector.Int64())
+		if spantype.EquivalentTypes(missingElem, missingElem) {
+			t.Error("ARRAY without element type should not be equivalent")
+		}
+		if spantype.EquivalentTypes(missingElem, validArray) {
+			t.Error("ARRAY without element type should not be equivalent to valid array")
+		}
+
+		malformedArray := &sppb.Type{
+			Code:             sppb.TypeCode_ARRAY,
+			ArrayElementType: typector.Int64(),
+			StructType:       &sppb.StructType{},
+		}
+		if spantype.EquivalentTypes(malformedArray, validArray) {
+			t.Error("malformed array with StructType should not be equivalent to valid array")
+		}
+	})
+
+	t.Run("malformed struct", func(t *testing.T) {
+		missingStruct := &sppb.Type{Code: sppb.TypeCode_STRUCT}
+		validStruct := typector.NameTypeToStructType("a", typector.Int64())
+		if spantype.EquivalentTypes(missingStruct, missingStruct) {
+			t.Error("STRUCT without StructType should not be equivalent")
+		}
+		if spantype.EquivalentTypes(missingStruct, validStruct) {
+			t.Error("STRUCT without StructType should not be equivalent to valid struct")
+		}
+
+		malformedStruct := &sppb.Type{
+			Code:             sppb.TypeCode_STRUCT,
+			StructType:       &sppb.StructType{Fields: []*sppb.StructType_Field{typector.NameTypeToStructTypeField("a", typector.Int64())}},
+			ArrayElementType: typector.Int64(),
+		}
+		if spantype.EquivalentTypes(malformedStruct, validStruct) {
+			t.Error("malformed struct with ArrayElementType should not be equivalent to valid struct")
+		}
+	})
+
+	t.Run("malformed proto and enum", func(t *testing.T) {
+		emptyProto := &sppb.Type{Code: sppb.TypeCode_PROTO}
+		if spantype.EquivalentTypes(emptyProto, emptyProto) {
+			t.Error("PROTO without FQN should not be equivalent")
+		}
+
+		emptyEnum := &sppb.Type{Code: sppb.TypeCode_ENUM}
+		if spantype.EquivalentTypes(emptyEnum, emptyEnum) {
+			t.Error("ENUM without FQN should not be equivalent")
+		}
+	})
 }

--- a/equivalent_test.go
+++ b/equivalent_test.go
@@ -46,3 +46,31 @@ func TestEquivalentTypesStructIgnoresFieldNames(t *testing.T) {
 		t.Fatalf("EquivalentTypes should ignore field names")
 	}
 }
+
+func TestEquivalentTypesPGNumericAnnotation(t *testing.T) {
+	t.Parallel()
+
+	if spantype.EquivalentTypes(typector.Numeric(), typector.PGNumeric()) {
+		t.Fatalf("GoogleSQL NUMERIC and PG_NUMERIC should not be equivalent")
+	}
+}
+
+func TestEquivalentTypesProtoFQNMismatch(t *testing.T) {
+	t.Parallel()
+
+	a := typector.FQNToProtoType("examples.Foo")
+	b := typector.FQNToProtoType("examples.Bar")
+	if spantype.EquivalentTypes(a, b) {
+		t.Fatalf("PROTO types with different FQN should not be equivalent")
+	}
+}
+
+func TestEquivalentTypesEnumFQNMismatch(t *testing.T) {
+	t.Parallel()
+
+	a := typector.FQNToEnumType("examples.Color")
+	b := typector.FQNToEnumType("examples.Size")
+	if spantype.EquivalentTypes(a, b) {
+		t.Fatalf("ENUM types with different FQN should not be equivalent")
+	}
+}

--- a/equivalent_test.go
+++ b/equivalent_test.go
@@ -1,0 +1,48 @@
+package spantype_test
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spantype"
+	"github.com/apstndb/spantype/typector"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestEquivalentTypesScalar(t *testing.T) {
+	t.Parallel()
+
+	a := typector.Int64()
+	b := typector.CodeToSimpleType(sppb.TypeCode_INT64)
+	if !spantype.EquivalentTypes(a, b) {
+		t.Fatalf("INT64 types should be equivalent")
+	}
+	if spantype.EquivalentTypes(a, typector.String()) {
+		t.Fatalf("INT64 and STRING should not be equivalent")
+	}
+}
+
+func TestEquivalentTypesArray(t *testing.T) {
+	t.Parallel()
+
+	elem := typector.Int64()
+	a := typector.ElemTypeToArrayType(elem)
+	b := typector.ElemTypeToArrayType(typector.CodeToSimpleType(sppb.TypeCode_INT64))
+	if !spantype.EquivalentTypes(a, b) {
+		t.Fatalf("ARRAY<INT64> types should be equivalent")
+	}
+}
+
+func TestEquivalentTypesStructIgnoresFieldNames(t *testing.T) {
+	t.Parallel()
+
+	fieldType := typector.Int64()
+	a := typector.NameTypeToStructType("a", fieldType)
+	b := typector.NameTypeToStructType("b", fieldType)
+	if proto.Equal(a, b) {
+		t.Fatalf("proto.Equal should distinguish STRUCT field names")
+	}
+	if !spantype.EquivalentTypes(a, b) {
+		t.Fatalf("EquivalentTypes should ignore field names")
+	}
+}

--- a/equivalent_test.go
+++ b/equivalent_test.go
@@ -74,3 +74,21 @@ func TestEquivalentTypesEnumFQNMismatch(t *testing.T) {
 		t.Fatalf("ENUM types with different FQN should not be equivalent")
 	}
 }
+
+func TestEquivalentTypesArrayContainerAnnotationMismatch(t *testing.T) {
+	t.Parallel()
+
+	elem := typector.Int64()
+	a := &sppb.Type{
+		Code:             sppb.TypeCode_ARRAY,
+		ArrayElementType: elem,
+	}
+	b := &sppb.Type{
+		Code:             sppb.TypeCode_ARRAY,
+		ArrayElementType: typector.CodeToSimpleType(sppb.TypeCode_INT64),
+		TypeAnnotation:   sppb.TypeAnnotationCode_PG_NUMERIC,
+	}
+	if spantype.EquivalentTypes(a, b) {
+		t.Fatalf("ARRAY types with different container TypeAnnotation should not be equivalent")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `spantype.EquivalentTypes` for comparing `*spannerpb.Type` metadata under Spanner-equivalence rules (scalar `proto.Equal`, recursive ARRAY/STRUCT layouts; STRUCT field names are not compared).
- Motivated by duplicate predicates in [spanvalue #259](https://github.com/apstndb/spanvalue/pull/259) and [memebridge](https://github.com/apstndb/memebridge) CAST/coercion paths.

## Test plan

- [x] `go test ./... -run EquivalentTypes`


Made with [Cursor](https://cursor.com)